### PR TITLE
Lights.on and Lights.reachable return invalid booleans

### DIFF
--- a/DPHue/DPHueLight.m
+++ b/DPHue/DPHueLight.m
@@ -220,8 +220,8 @@
     _colorMode = d[@"state"][@"colormode"];
     _hue = d[@"state"][@"hue"];
     _type = d[@"type"];
-    _on = (BOOL)d[@"state"][@"on"];
-    _reachable = (BOOL)d[@"state"][@"reachable"];
+    _on = [d[@"state"][@"on"] boolValue];
+    _reachable = [d[@"state"][@"reachable"] boolValue];
     _xy = d[@"state"][@"xy"];
     _colorTemperature = d[@"state"][@"ct"];
     _saturation = d[@"state"][@"sat"];


### PR DESCRIPTION
The bool returned results into an 92 and 100 for string "1" and string "0" due to being simply casted to a boolean. Changed it to use the 'boolValue' function on NSString, now works properly.
